### PR TITLE
make mlr3cluster usable for pipelines:

### DIFF
--- a/R/MeasureClustInternal.R
+++ b/R/MeasureClustInternal.R
@@ -20,8 +20,8 @@ MeasureClustInternal = R6Class("MeasureClustInternal",
     }
   ),
   private = list(
-    .score = function(prediction, task, ...) {
-      X = as.matrix(task$data(rows = prediction$row_ids))
+    .score = function(prediction, ...) {
+      X = as.matrix(prediction$data$task$data(rows = prediction$row_ids))
       if (!is.double(X)) { # clusterCrit does not convert lgls/ints
         storage.mode(X) = "double"
       }

--- a/R/PredictionClust.R
+++ b/R/PredictionClust.R
@@ -39,7 +39,8 @@ PredictionClust = R6Class("PredictionClust",
     #' @param check (`logical(1)`)\cr
     #'   If `TRUE`, performs some argument checks and predict type conversions.
     initialize = function(task = NULL, row_ids = task$row_ids, partition = NULL, prob = NULL, check = TRUE) {
-      pdata = list(row_ids = row_ids, partition = partition, prob = prob)
+      pdata = list(row_ids = row_ids, partition = partition,
+                   prob = prob, task = task)
       pdata = discard(pdata, is.null)
       class(pdata) = c("PredictionDataClust", "PredictionData")
 


### PR DESCRIPTION
store task in the prediction and make measures rely on this task.
This makes mlr3cluster usable for mlr3pipelines

Solves #13 