### PR TITLE
refactor: remove unused setup.R file for tests, remove unneeded nesting of if stmts, remove `c()` when only a single value, use fixed in grep where no regex used

### DIFF
--- a/R/LearnerClust.R
+++ b/R/LearnerClust.R
@@ -63,5 +63,5 @@ LearnerClust = R6Class("LearnerClust",
       self$assignments = NULL
       super$reset()
     }
-  ),
+  )
 )

--- a/R/LearnerClustDBSCANfpc.R
+++ b/R/LearnerClustDBSCANfpc.R
@@ -48,7 +48,7 @@ LearnerClustDBSCANfpc = R6Class("LearnerClustDBSCANfpc",
         id = "clust.dbscan_fpc",
         packages = "fpc",
         feature_types = c("logical", "integer", "numeric"),
-        predict_types = c("partition"),
+        predict_types = "partition",
         param_set = param_set,
         properties = c("partitional", "exclusive", "complete"),
         man = "mlr3cluster::mlr_learners_clust.dbscan_fpc",
@@ -62,7 +62,7 @@ LearnerClustDBSCANfpc = R6Class("LearnerClustDBSCANfpc",
       m = invoke(fpc::dbscan, data = task$data(), .args = pars)
       m = set_class(
         list(cluster = m$cluster, eps = m$eps, MinPts = m$MinPts, isseed = m$isseed, data = task$data()),
-        c("dbscan")
+        "dbscan"
       )
       if (self$save_assignments) {
         self$assignments = m$cluster

--- a/R/LearnerClustKKMeans.R
+++ b/R/LearnerClustKKMeans.R
@@ -93,7 +93,7 @@ LearnerClustKKMeans = R6Class("LearnerClustKKMeans",
       # this is the squared kernel distance to the centers
       d2 = d_xx + d_cc - 2 * d_xc
       # the nearest center determines cluster assignment
-      partition = apply(d2, 1, function(x) which.min(x))
+      partition = apply(d2, 1L, which.min)
 
       PredictionClust$new(task = task, partition = partition)
     }

--- a/R/LearnerClustKMeans.R
+++ b/R/LearnerClustKMeans.R
@@ -26,12 +26,12 @@ LearnerClustKMeans = R6Class("LearnerClustKMeans",
         centers = p_uty(
           tags = c("required", "train"), default = 2L, custom_check = crate(check_centers)
         ),
-        iter.max = p_int(1L, default = 10L, tags = c("train")),
+        iter.max = p_int(1L, default = 10L, tags = "train"),
         algorithm = p_fct(
-          levels = c("Hartigan-Wong", "Lloyd", "Forgy", "MacQueen"), default = "Hartigan-Wong", tags = c("train")
+          levels = c("Hartigan-Wong", "Lloyd", "Forgy", "MacQueen"), default = "Hartigan-Wong", tags = "train"
         ),
-        nstart = p_int(1L, default = 1L, tags = c("train")),
-        trace = p_int(0L, default = 0L, tags = c("train"))
+        nstart = p_int(1L, default = 1L, tags = "train"),
+        trace = p_int(0L, default = 0L, tags = "train")
       )
       param_set$set_values(centers = 2L)
 
@@ -50,10 +50,8 @@ LearnerClustKMeans = R6Class("LearnerClustKMeans",
 
   private = list(
     .train = function(task) {
-      if ("nstart" %in% names(self$param_set$values)) {
-        if (!test_int(self$param_set$values$centers)) {
-          warningf("`nstart` parameter is only relevant when `centers` is integer.")
-        }
+      if ("nstart" %in% names(self$param_set$values) && !test_int(self$param_set$values$centers)) {
+        warningf("`nstart` parameter is only relevant when `centers` is integer.")
       }
 
       check_centers_param(self$param_set$values$centers, task, test_data_frame, "centers")

--- a/R/LearnerClustMeanShift.R
+++ b/R/LearnerClustMeanShift.R
@@ -48,10 +48,8 @@ LearnerClustMeanShift = R6Class("LearnerClustMeanShift",
   ),
   private = list(
     .train = function(task) {
-      if (!is.null(self$param_set$values$subset)) {
-        if (length(self$param_set$values$subset) > task$nrow) {
-          stopf("`subset` length must be less than or equal to number of observations in task")
-        }
+      if (!is.null(self$param_set$values$subset) && length(self$param_set$values$subset) > task$nrow) {
+        stopf("`subset` length must be less than or equal to number of observations in task")
       }
 
       pv = self$param_set$get_values(tags = "train")

--- a/R/LearnerClustMiniBatchKMeans.R
+++ b/R/LearnerClustMiniBatchKMeans.R
@@ -59,10 +59,9 @@ LearnerClustMiniBatchKMeans = R6Class("LearnerClustMiniBatchKMeans",
   private = list(
     .train = function(task) {
       check_centers_param(self$param_set$values$CENTROIDS, task, test_matrix, "CENTROIDS")
-      if (test_matrix(self$param_set$values$CENTROIDS)) {
-        if (nrow(self$param_set$values$CENTROIDS) != self$param_set$values$clusters) {
-          stopf("`CENTROIDS` must have same number of rows as `clusters`")
-        }
+      if (test_matrix(self$param_set$values$CENTROIDS) &&
+            nrow(self$param_set$values$CENTROIDS) != self$param_set$values$clusters) {
+        stopf("`CENTROIDS` must have same number of rows as `clusters`")
       }
 
       pv = self$param_set$get_values(tags = "train")

--- a/R/LearnerClustPAM.R
+++ b/R/LearnerClustPAM.R
@@ -31,7 +31,7 @@ LearnerClustPAM = R6Class("LearnerClustPAM",
         ),
         stand = p_lgl(default = FALSE, tags = "train"),
         do.swap = p_lgl(default = TRUE, tags = "train"),
-        pamonce = p_int(0L, 5L, default = 0, tags = "train"),
+        pamonce = p_int(0L, 5L, default = 0L, tags = "train"),
         trace.lev = p_int(0L, default = 0L, tags = "train")
       )
       param_set$set_values(k = 2L)
@@ -53,15 +53,14 @@ LearnerClustPAM = R6Class("LearnerClustPAM",
       if (!is.null(self$param_set$values$medoids)) {
         if (test_true(length(self$param_set$values$medoids) != self$param_set$values$k)) {
           stopf("number of `medoids`' needs to match `k`!")
-        } else {
-          r = unname(lapply(self$param_set$values$medoids, function(i) {
-            test_true(i <= task$nrow) && test_true(i >= 1)
-          }))
-          if (sum(unlist(r)) != self$param_set$values$k) {
-            msg = sprintf("`medoids` need to contain valid indices from 1")
-            msg = sprintf("%s to %s (number of observations)!", msg, self$param_set$values$k)
-            stopf(msg)
-          }
+        }
+        r = map_lgl(self$param_set$values$medoids, function(i) {
+          test_true(i <= task$nrow) && test_true(i >= 1L)
+        })
+        if (sum(r) != self$param_set$values$k) {
+          msg = sprintf("`medoids` need to contain valid indices from 1")
+          msg = sprintf("%s to %s (number of observations)!", msg, self$param_set$values$k)
+          stopf(msg)
         }
       }
 

--- a/R/helper.R
+++ b/R/helper.R
@@ -10,10 +10,8 @@ allow_partial_matching = list(
 )
 
 check_centers_param = function(centers, task, test_class, name) {
-  if (test_class(centers)) {
-    if (ncol(centers) != task$ncol) {
-      stopf("`%s` must have same number of columns as data.", name)
-    }
+  if (test_class(centers) && ncol(centers) != task$ncol) {
+    stopf("`%s` must have same number of columns as data.", name)
   }
 }
 

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,5 +1,0 @@
-old_opts = options(
-  warnPartialMatchArgs = TRUE,
-  warnPartialMatchAttr = TRUE,
-  warnPartialMatchDollar = TRUE
-)

--- a/tests/testthat/test_LearnerClust.R
+++ b/tests/testthat/test_LearnerClust.R
@@ -39,7 +39,7 @@ test_that("empty predict set (#421)", {
   hout = resampling$instantiate(task)
   model = learner$train(task, hout$train_set(1))
   pred = learner$predict(task, hout$test_set(1))
-  expect_true(any(grepl("No data to predict on", learner$log$msg)))
+  expect_true(any(grepl("No data to predict on", learner$log$msg, fixed = TRUE)))
 })
 
 test_that("assignment saving works", {


### PR DESCRIPTION
- Replace `lapply` for `map_*` functions
- Remove `c()` when single value
- Remove unneeded nesting of if stmts
- Use fixed for `grep` when not using regex
- Remove unused `tests/testthat/setup.R` file