### PR TITLE
refactor: use predict generic for mini-batch kmeans

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,10 +1,10 @@
 linters: linters_with_defaults(
-    # lintr defaults: https://github.com/jimhester/lintr#available-linters
+    # lintr defaults: https://lintr.r-lib.org/reference/default_linters.html
     # the following setup changes/removes certain linters
     assignment_linter = NULL, # do not force using <- for assignments
     object_name_linter = object_name_linter(c("snake_case", "CamelCase")), # only allow snake case and camel case object names
     cyclocomp_linter = NULL, # do not check function complexity
     commented_code_linter = NULL, # allow code in comments
-    line_length_linter = line_length_linter(120),
-    object_length_linter = object_length_linter(40)
+    line_length_linter = line_length_linter(120L),
+    object_length_linter = object_length_linter(40L)
     )

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,7 @@ repos:
         - mlr3
         - mlr3misc
         - paradox
+        - stream
       # codemeta must be above use-tidy-description when both are used
       - id: use-tidy-description
       - id: readme-rmd-rendered

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # R specific hooks: https://github.com/lorenzwalthert/precommit
 repos:
   - repo: https://github.com/lorenzwalthert/precommit
-    rev: v0.4.0
+    rev: v0.4.2
     hooks:
       - id: style-files
         args: [--style_pkg=styler.mlr, --style_fun=mlr_style]
@@ -38,7 +38,7 @@ repos:
       - id: deps-in-desc
         exclude: data-raw|inst
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-added-large-files
         args: [--maxkb=200]

--- a/R/LearnerClust.R
+++ b/R/LearnerClust.R
@@ -42,7 +42,6 @@ LearnerClust = R6Class("LearnerClust",
     #' Default is `TRUE`.
     save_assignments = TRUE,
 
-
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.
     initialize = function(id, param_set = ps(), predict_types = "partition", feature_types = character(),

--- a/R/LearnerClustAffinityPropagation.R
+++ b/R/LearnerClustAffinityPropagation.R
@@ -62,8 +62,7 @@ LearnerClustAP = R6Class("LearnerClustAP",
       if (self$save_assignments) {
         self$assignments = apcluster::labels(m, type = "enum")
       }
-
-      return(m)
+      m
     },
 
     .predict = function(task) {

--- a/R/LearnerClustAgnes.R
+++ b/R/LearnerClustAgnes.R
@@ -73,8 +73,7 @@ LearnerClustAgnes = R6Class("LearnerClustAgnes",
       if (self$save_assignments) {
         self$assignments = stats::cutree(m, pv$k)
       }
-
-      return(m)
+      m
     },
 
     .predict = function(task) {

--- a/R/LearnerClustBICO.R
+++ b/R/LearnerClustBICO.R
@@ -51,8 +51,7 @@ LearnerClustBICO = R6Class("LearnerClustBICO",
       if (self$save_assignments) {
         self$assignments = as.integer(invoke(predict, m, newdata = dt)[[1L]])
       }
-
-      return(m)
+      m
     },
 
     .predict = function(task) {

--- a/R/LearnerClustBIRCH.R
+++ b/R/LearnerClustBIRCH.R
@@ -52,8 +52,7 @@ LearnerClustBIRCH = R6Class("LearnerClustBIRCH",
       if (self$save_assignments) {
         self$assignments = as.integer(invoke(predict, m, newdata = dt)[[1L]])
       }
-
-      return(m)
+      m
     },
 
     .predict = function(task) {

--- a/R/LearnerClustCMeans.R
+++ b/R/LearnerClustCMeans.R
@@ -69,8 +69,7 @@ LearnerClustCMeans = R6Class("LearnerClustCMeans",
       if (self$save_assignments) {
         self$assignments = m$cluster
       }
-
-      return(m)
+      m
     },
 
     .predict = function(task) {

--- a/R/LearnerClustCobweb.R
+++ b/R/LearnerClustCobweb.R
@@ -48,8 +48,7 @@ LearnerClustCobweb = R6Class("LearnerClustCobweb",
       if (self$save_assignments) {
         self$assignments = unname(m$class_ids + 1L)
       }
-
-      return(m)
+      m
     },
 
     .predict = function(task) {

--- a/R/LearnerClustDBSCAN.R
+++ b/R/LearnerClustDBSCAN.R
@@ -57,8 +57,7 @@ LearnerClustDBSCAN = R6Class("LearnerClustDBSCAN",
       if (self$save_assignments) {
         self$assignments = m$cluster
       }
-
-      return(m)
+      m
     },
 
     .predict = function(task) {

--- a/R/LearnerClustDBSCANfpc.R
+++ b/R/LearnerClustDBSCANfpc.R
@@ -67,8 +67,7 @@ LearnerClustDBSCANfpc = R6Class("LearnerClustDBSCANfpc",
       if (self$save_assignments) {
         self$assignments = m$cluster
       }
-
-      return(m)
+      m
     },
 
     .predict = function(task) {

--- a/R/LearnerClustDBSCANfpc.R
+++ b/R/LearnerClustDBSCANfpc.R
@@ -28,7 +28,7 @@ LearnerClustDBSCANfpc = R6Class("LearnerClustDBSCANfpc",
         method = p_fct(levels = c("hybrid", "raw", "dist"), tags = "train"),
         seeds = p_lgl(default = TRUE, tags = "train"),
         showplot = p_uty(default = FALSE, tags = "train", custom_check = crate(function(x) {
-          if (test_flag(x) || test_int(x, lower = 0, upper = 2)) {
+          if (test_flag(x) || test_int(x, lower = 0L, upper = 2L)) {
             TRUE
           } else {
             "`showplot` need to be either logical or integer between 0 and 2"
@@ -61,8 +61,8 @@ LearnerClustDBSCANfpc = R6Class("LearnerClustDBSCANfpc",
   ),
   private = list(
     .train = function(task) {
-      pars = self$param_set$get_values(tags = "train")
-      m = invoke(fpc::dbscan, data = task$data(), .args = pars)
+      pv = self$param_set$get_values(tags = "train")
+      m = invoke(fpc::dbscan, data = task$data(), .args = pv)
       m = insert_named(m, list(data = task$data()))
       if (self$save_assignments) {
         self$assignments = m$cluster

--- a/R/LearnerClustDiana.R
+++ b/R/LearnerClustDiana.R
@@ -54,8 +54,7 @@ LearnerClustDiana = R6Class("LearnerClustDiana",
       if (self$save_assignments) {
         self$assignments = stats::cutree(m, pv$k)
       }
-
-      return(m)
+      m
     },
 
     .predict = function(task) {

--- a/R/LearnerClustEM.R
+++ b/R/LearnerClustEM.R
@@ -59,8 +59,7 @@ LearnerClustEM = R6Class("LearnerClustEM",
       if (self$save_assignments) {
         self$assignments = unname(m$class_ids + 1L)
       }
-
-      return(m)
+      m
     },
 
     .predict = function(task) {

--- a/R/LearnerClustFanny.R
+++ b/R/LearnerClustFanny.R
@@ -56,8 +56,7 @@ LearnerClustFanny = R6Class("LearnerClustFanny",
       if (self$save_assignments) {
         self$assignments = m$clustering
       }
-
-      return(m)
+      m
     },
 
     .predict = function(task) {

--- a/R/LearnerClustFarthestFirst.R
+++ b/R/LearnerClustFarthestFirst.R
@@ -49,8 +49,7 @@ LearnerClustFarthestFirst = R6Class("LearnerClustFF",
       if (self$save_assignments) {
         self$assignments = unname(m$class_ids + 1L)
       }
-
-      return(m)
+      m
     },
 
     .predict = function(task) {

--- a/R/LearnerClustHDBSCAN.R
+++ b/R/LearnerClustHDBSCAN.R
@@ -49,8 +49,7 @@ LearnerClustHDBSCAN = R6Class("LearnerClustHDBSCAN",
       if (self$save_assignments) {
         self$assignments = m$cluster
       }
-
-      return(m)
+      m
     },
 
     .predict = function(task) {

--- a/R/LearnerClustHclust.R
+++ b/R/LearnerClustHclust.R
@@ -69,8 +69,7 @@ LearnerClustHclust = R6Class("LearnerClustHclust",
       if (self$save_assignments) {
         self$assignments = stats::cutree(m, pv$k)
       }
-
-      return(m)
+      m
     },
 
     .predict = function(task) {

--- a/R/LearnerClustKKMeans.R
+++ b/R/LearnerClustKKMeans.R
@@ -72,7 +72,7 @@ LearnerClustKKMeans = R6Class("LearnerClustKKMeans",
       if (self$save_assignments) {
         self$assignments = m[seq_along(m)]
       }
-      return(m)
+      m
     },
 
     .predict = function(task) {

--- a/R/LearnerClustKMeans.R
+++ b/R/LearnerClustKMeans.R
@@ -63,8 +63,7 @@ LearnerClustKMeans = R6Class("LearnerClustKMeans",
       if (self$save_assignments) {
         self$assignments = m$cluster
       }
-
-      return(m)
+      m
     },
 
     .predict = function(task) {

--- a/R/LearnerClustMclust.R
+++ b/R/LearnerClustMclust.R
@@ -52,8 +52,7 @@ LearnerClustMclust = R6Class("LearnerClustMclust",
       if (self$save_assignments) {
         self$assignments = m$classification
       }
-
-      return(m)
+      m
     },
 
     .predict = function(task) {

--- a/R/LearnerClustMeanShift.R
+++ b/R/LearnerClustMeanShift.R
@@ -59,8 +59,7 @@ LearnerClustMeanShift = R6Class("LearnerClustMeanShift",
       if (self$save_assignments) {
         self$assignments = m$cluster.label
       }
-
-      return(m)
+      m
     },
 
     .predict = function(task) {

--- a/R/LearnerClustMiniBatchKMeans.R
+++ b/R/LearnerClustMiniBatchKMeans.R
@@ -70,8 +70,7 @@ LearnerClustMiniBatchKMeans = R6Class("LearnerClustMiniBatchKMeans",
       if (self$save_assignments) {
         self$assignments = as.integer(invoke(predict, m, newdata = task$data()))
       }
-
-      return(m)
+      m
     },
 
     .predict = function(task) {

--- a/R/LearnerClustMiniBatchKMeans.R
+++ b/R/LearnerClustMiniBatchKMeans.R
@@ -68,41 +68,20 @@ LearnerClustMiniBatchKMeans = R6Class("LearnerClustMiniBatchKMeans",
 
       m = invoke(ClusterR::MiniBatchKmeans, data = task$data(), .args = pv)
       if (self$save_assignments) {
-        self$assignments = unclass(invoke(ClusterR::predict_MBatchKMeans,
-          data = task$data(),
-          CENTROIDS = m$centroids,
-          fuzzy = FALSE
-        ))
-        self$assignments = as.integer(self$assignments)
+        self$assignments = as.integer(invoke(predict, m, newdata = task$data()))
       }
 
       return(m)
     },
 
     .predict = function(task) {
-      if (self$predict_type == "partition") {
-        partition = unclass(invoke(ClusterR::predict_MBatchKMeans,
-          data = task$data(),
-          CENTROIDS = self$model$centroids,
-          fuzzy = FALSE
-        ))
-        partition = as.integer(partition)
-        pred = PredictionClust$new(task = task, partition = partition)
-      } else if (self$predict_type == "prob") {
-        partition = unclass(invoke(ClusterR::predict_MBatchKMeans,
-          data = task$data(),
-          CENTROIDS = self$model$centroids,
-          fuzzy = TRUE
-        ))
-        colnames(partition$fuzzy_clusters) = seq_len(ncol(partition$fuzzy_clusters))
-        pred = PredictionClust$new(
-          task = task,
-          partition = as.integer(partition$clusters),
-          prob = partition$fuzzy_clusters
-        )
+      partition = as.integer(invoke(predict, self$model, newdata = task$data()))
+      prob = NULL
+      if (self$predict_type == "prob") {
+        prob = invoke(predict, self$model, newdata = task$data(), fuzzy = TRUE)
+        colnames(prob) = seq_len(ncol(prob))
       }
-
-      return(pred)
+      PredictionClust$new(task = task, partition = partition, prob = prob)
     }
   )
 )

--- a/R/LearnerClustOPTICS.R
+++ b/R/LearnerClustOPTICS.R
@@ -58,8 +58,7 @@ LearnerClustOPTICS = R6Class("LearnerClustOPTICS",
       if (self$save_assignments) {
         self$assignments = m$cluster
       }
-
-      return(m)
+      m
     },
 
     .predict = function(task) {

--- a/R/LearnerClustPAM.R
+++ b/R/LearnerClustPAM.R
@@ -67,8 +67,7 @@ LearnerClustPAM = R6Class("LearnerClustPAM",
       if (self$save_assignments) {
         self$assignments = m$clustering
       }
-
-      return(m)
+      m
     },
 
     .predict = function(task) {

--- a/R/LearnerClustSimpleKMeans.R
+++ b/R/LearnerClustSimpleKMeans.R
@@ -63,8 +63,7 @@ LearnerClustSimpleKMeans = R6Class("LearnerClustSimpleKMeans",
       if (self$save_assignments) {
         self$assignments = unname(m$class_ids + 1L)
       }
-
-      return(m)
+      m
     },
 
     .predict = function(task) {

--- a/R/LearnerClustXMeans.R
+++ b/R/LearnerClustXMeans.R
@@ -62,8 +62,7 @@ LearnerClustXMeans = R6Class("LearnerClustXMeans",
       if (self$save_assignments) {
         self$assignments = unname(m$class_ids + 1L)
       }
-
-      return(m)
+      m
     },
 
     .predict = function(task) {

--- a/R/MeasureClustInternal.R
+++ b/R/MeasureClustInternal.R
@@ -27,7 +27,6 @@ MeasureClustFPC = R6Class("MeasureClustFPC",
   )
 )
 
-
 MeasureClustSil = R6Class("MeasureClustSil",
   inherit = MeasureClust,
   public = list(
@@ -66,20 +65,17 @@ MeasureClustSil = R6Class("MeasureClustSil",
 #' @template measure_sil
 measures$silhouette = make_measure_info("sil_width", "Silhouette", lower = 0, upper = Inf, minimize = FALSE)
 
-
 #' @title Calinski Harabasz Pseudo F-Statistic
 #'
 #' @templateVar id ch
 #' @template measure_fpc
 measures$ch = make_measure_info("ch", "Calinski Harabasz", lower = 0, upper = Inf, minimize = FALSE)
 
-
 #' @title Dunn Index
 #'
 #' @templateVar id dunn
 #' @template measure_fpc
 measures$dunn = make_measure_info("dunn", "Dunn", lower = 0, upper = Inf, minimize = FALSE)
-
 
 #' @title Within Sum of Squares
 #'

--- a/R/MeasureClustInternal.R
+++ b/R/MeasureClustInternal.R
@@ -51,9 +51,9 @@ MeasureClustSil = R6Class("MeasureClustSil",
       X = dist(task$data(rows = prediction$row_ids))
 
       if (length(unique(prediction$partition)) == 1L) {
-        return(0L)
+        0L
       } else {
-        return(mean(silhouette(prediction$partition, X)[, self$crit]))
+        mean(silhouette(prediction$partition, X)[, self$crit])
       }
     }
   )

--- a/R/PredictionClust.R
+++ b/R/PredictionClust.R
@@ -67,7 +67,6 @@ PredictionClust = R6Class("PredictionClust",
   )
 )
 
-
 #' @export
 as.data.table.PredictionClust = function(x, ...) { # nolint
   tab = as.data.table(x$data[c("row_ids", "partition")])

--- a/R/PredictionDataClust.R
+++ b/R/PredictionDataClust.R
@@ -28,7 +28,6 @@ check_prediction_data.PredictionDataClust = function(pdata, ...) { # nolint
   pdata
 }
 
-
 #' @export
 is_missing_prediction_data.PredictionDataClust = function(pdata, ...) { # nolint
   miss = logical(length(pdata$row_ids))

--- a/R/TaskClust_ruspini.R
+++ b/R/TaskClust_ruspini.R
@@ -1,10 +1,10 @@
 #' @title Ruspini Cluster Task
 #'
 #' @name mlr_tasks_ruspini
-#' @include aaa.R
 #' @format [R6::R6Class] inheriting from [TaskClust].
 #'
 #' @section Construction:
+#'
 #' ```
 #' mlr_tasks$get("ruspini")
 #' tsk("ruspini")
@@ -25,4 +25,5 @@ load_task_ruspini = function(id = "ruspini") {
   task
 }
 
+#' @include aaa.R
 tasks[["ruspini"]] = load_task_ruspini

--- a/R/TaskClust_ruspini.R
+++ b/R/TaskClust_ruspini.R
@@ -3,19 +3,16 @@
 #' @name mlr_tasks_ruspini
 #' @format [R6::R6Class] inheriting from [TaskClust].
 #'
-#' @section Construction:
-#'
-#' ```
-#' mlr_tasks$get("ruspini")
-#' tsk("ruspini")
-#' ```
-#'
 #' @description
 #' A cluster task for the [cluster::ruspini] data set.
 #'
-#' @source
+#' @templateVar id ruspini
+#' @template task
+#'
+#' @references
 #' `r format_bib("ruspini_1970")`
 #'
+#' @template seealso_task
 NULL
 
 load_task_ruspini = function(id = "ruspini") {

--- a/R/TaskClust_usarrest.R
+++ b/R/TaskClust_usarrest.R
@@ -3,17 +3,17 @@
 #' @name mlr_tasks_usarrests
 #' @format [R6::R6Class] inheriting from [TaskClust].
 #'
-#' @section Construction:
-#'
-#' ```
-#' mlr_tasks$get("usarrests")
-#' tsk("usarrests")
-#' ```
-#'
 #' @description
 #' A cluster task for the [datasets::USArrests] data set.
 #' Rownames are stored as variable `"states"` with column role `"name"`.
 #'
+#' @templateVar id usarrests
+#' @template task
+#'
+#' @references
+#' `r format_bib("berry1979inter")`
+#'
+#' @template seealso_task
 NULL
 
 load_task_usarrests = function(id = "usarrests") {

--- a/R/TaskClust_usarrest.R
+++ b/R/TaskClust_usarrest.R
@@ -1,10 +1,10 @@
 #' @title US Arrests Cluster Task
 #'
 #' @name mlr_tasks_usarrests
-#' @include aaa.R
 #' @format [R6::R6Class] inheriting from [TaskClust].
 #'
 #' @section Construction:
+#'
 #' ```
 #' mlr_tasks$get("usarrests")
 #' tsk("usarrests")
@@ -25,4 +25,5 @@ load_task_usarrests = function(id = "usarrests") {
   task
 }
 
+#' @include aaa.R
 tasks[["usarrests"]] = load_task_usarrests

--- a/R/as_prediction_clust.R
+++ b/R/as_prediction_clust.R
@@ -36,13 +36,11 @@ as_prediction_clust = function(x, ...) {
   UseMethod("as_prediction_clust")
 }
 
-
 #' @rdname as_prediction_clust
 #' @export
 as_prediction_clust.PredictionClust = function(x, ...) { # nolint
   x
 }
-
 
 #' @rdname as_prediction_clust
 #' @export

--- a/R/as_task_clust.R
+++ b/R/as_task_clust.R
@@ -17,7 +17,6 @@ as_task_clust = function(x, ...) {
   UseMethod("as_task_clust")
 }
 
-
 #' @rdname as_task_clust
 #' @param clone (`logical(1)`)\cr
 #'   If `TRUE`, ensures that the returned object is not the same as the input `x`.
@@ -25,7 +24,6 @@ as_task_clust = function(x, ...) {
 as_task_clust.TaskClust = function(x, clone = FALSE, ...) { # nolint
   if (clone) x$clone() else x
 }
-
 
 #' @rdname as_task_clust
 #' @param id (`character(1)`)\cr
@@ -40,7 +38,6 @@ as_task_clust.data.frame = function(x, id = deparse(substitute(x)), ...) { # nol
 
   TaskClust$new(id = id, backend = x)
 }
-
 
 #' @rdname as_task_clust
 #' @export

--- a/R/bibentries.R
+++ b/R/bibentries.R
@@ -357,5 +357,13 @@ bibentries = c( # nolint start
     pages = "141--182",
     year = "1997",
     publisher = "Springer"
+  ),
+  berry1979inter = bibentry("article",
+    title = "Interactive Data Analysis: A Practical Primer",
+    author = "Berry, J. Brian",
+    journal = "Journal of the Royal Statistical Society: Series C (Applied Statistics)",
+    volume = "28",
+    pages = "181",
+    year = "1979"
   )
 ) # nolint end

--- a/man-roxygen/seealso_task.R
+++ b/man-roxygen/seealso_task.R
@@ -1,0 +1,15 @@
+#' @seealso
+#'
+#' * Chapter in the [mlr3book](https://mlr3book.mlr-org.com/):
+#'   \url{https://mlr3book.mlr-org.com/chapters/chapter2/data_and_basic_modeling.html}
+#' * Package \CRANpkg{mlr3data} for more toy tasks.
+#' * Package \CRANpkg{mlr3oml} for downloading tasks from \url{https://www.openml.org}.
+#' * Package \CRANpkg{mlr3viz} for some generic visualizations.
+#' * [Dictionary][mlr3misc::Dictionary] of [Tasks][Task]: [mlr_tasks]
+#' * `as.data.table(mlr_tasks)` for a table of available [Tasks][Task] in the running session (depending on the loaded packages).
+#' * \CRANpkg{mlr3fselect} and \CRANpkg{mlr3filters} for feature selection and feature filtering.
+#' * Extension packages for additional task types:
+#'    * Unsupervised clustering: \CRANpkg{mlr3cluster}
+#'    * Probabilistic supervised regression and survival analysis: \url{https://mlr3proba.mlr-org.com/}.
+#'
+#' @family Task

--- a/man-roxygen/task.R
+++ b/man-roxygen/task.R
@@ -1,0 +1,10 @@
+#' @section Dictionary:
+#' This [Task] can be instantiated via the [dictionary][mlr3misc::Dictionary] [mlr_tasks] or with the associated sugar function [tsk()]:
+#' ```
+#' mlr_tasks$get("<%= id %>")
+#' tsk("<%= id %>")
+#' ```
+#'
+#' @section Meta Information:
+#' `r mlr3misc::rd_info(mlr3::tsk("<%= id %>"))`
+#' @md

--- a/man/TaskClust.Rd
+++ b/man/TaskClust.Rd
@@ -19,6 +19,11 @@ task$task_type
 # possible properties:
 mlr_reflections$task_properties$clust
 }
+\seealso{
+Other Task: 
+\code{\link{mlr_tasks_ruspini}},
+\code{\link{mlr_tasks_usarrests}}
+}
 \concept{Task}
 \section{Super classes}{
 \code{\link[mlr3:Task]{mlr3::Task}} -> \code{\link[mlr3:TaskUnsupervised]{mlr3::TaskUnsupervised}} -> \code{TaskClust}

--- a/man/mlr_tasks_ruspini.Rd
+++ b/man/mlr_tasks_ruspini.Rd
@@ -6,20 +6,55 @@
 \format{
 \link[R6:R6Class]{R6::R6Class} inheriting from \link{TaskClust}.
 }
-\source{
-Ruspini EH (1970).
-\dQuote{Numerical methods for fuzzy clustering.}
-\emph{Information Sciences}, \bold{2}(3), 319-350.
-\doi{10.1016/S0020-0255(70)80056-1}.
-}
 \description{
 A cluster task for the \link[cluster:ruspini]{cluster::ruspini} data set.
 }
-\section{Construction}{
+\section{Dictionary}{
 
+This \link{Task} can be instantiated via the \link[mlr3misc:Dictionary]{dictionary} \link{mlr_tasks} or with the associated sugar function \code{\link[=tsk]{tsk()}}:
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{mlr_tasks$get("ruspini")
 tsk("ruspini")
 }\if{html}{\out{</div>}}
 }
 
+\section{Meta Information}{
+
+\itemize{
+\item Task type: \dQuote{clust}
+\item Dimensions: 75x2
+\item Properties: -
+\item Has Missings: \code{FALSE}
+\item Target: -
+\item Features: \dQuote{x}, \dQuote{y}
+}
+}
+
+\references{
+Ruspini EH (1970).
+\dQuote{Numerical methods for fuzzy clustering.}
+\emph{Information Sciences}, \bold{2}(3), 319-350.
+\doi{10.1016/S0020-0255(70)80056-1}.
+}
+\seealso{
+\itemize{
+\item Chapter in the \href{https://mlr3book.mlr-org.com/}{mlr3book}:
+\url{https://mlr3book.mlr-org.com/chapters/chapter2/data_and_basic_modeling.html}
+\item Package \CRANpkg{mlr3data} for more toy tasks.
+\item Package \CRANpkg{mlr3oml} for downloading tasks from \url{https://www.openml.org}.
+\item Package \CRANpkg{mlr3viz} for some generic visualizations.
+\item \link[mlr3misc:Dictionary]{Dictionary} of \link[=Task]{Tasks}: \link{mlr_tasks}
+\item \code{as.data.table(mlr_tasks)} for a table of available \link[=Task]{Tasks} in the running session (depending on the loaded packages).
+\item \CRANpkg{mlr3fselect} and \CRANpkg{mlr3filters} for feature selection and feature filtering.
+\item Extension packages for additional task types:
+\itemize{
+\item Unsupervised clustering: \CRANpkg{mlr3cluster}
+\item Probabilistic supervised regression and survival analysis: \url{https://mlr3proba.mlr-org.com/}.
+}
+}
+
+Other Task: 
+\code{\link{TaskClust}},
+\code{\link{mlr_tasks_usarrests}}
+}
+\concept{Task}

--- a/man/mlr_tasks_usarrests.Rd
+++ b/man/mlr_tasks_usarrests.Rd
@@ -10,11 +10,51 @@
 A cluster task for the \link[datasets:USArrests]{datasets::USArrests} data set.
 Rownames are stored as variable \code{"states"} with column role \code{"name"}.
 }
-\section{Construction}{
+\section{Dictionary}{
 
+This \link{Task} can be instantiated via the \link[mlr3misc:Dictionary]{dictionary} \link{mlr_tasks} or with the associated sugar function \code{\link[=tsk]{tsk()}}:
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{mlr_tasks$get("usarrests")
 tsk("usarrests")
 }\if{html}{\out{</div>}}
 }
 
+\section{Meta Information}{
+
+\itemize{
+\item Task type: \dQuote{clust}
+\item Dimensions: 50x4
+\item Properties: -
+\item Has Missings: \code{FALSE}
+\item Target: -
+\item Features: \dQuote{Assault}, \dQuote{Murder}, \dQuote{Rape}, \dQuote{UrbanPop}
+}
+}
+
+\references{
+Berry, Brian J (1979).
+\dQuote{Interactive Data Analysis: A Practical Primer.}
+\emph{Journal of the Royal Statistical Society: Series C (Applied Statistics)}, \bold{28}, 181.
+}
+\seealso{
+\itemize{
+\item Chapter in the \href{https://mlr3book.mlr-org.com/}{mlr3book}:
+\url{https://mlr3book.mlr-org.com/chapters/chapter2/data_and_basic_modeling.html}
+\item Package \CRANpkg{mlr3data} for more toy tasks.
+\item Package \CRANpkg{mlr3oml} for downloading tasks from \url{https://www.openml.org}.
+\item Package \CRANpkg{mlr3viz} for some generic visualizations.
+\item \link[mlr3misc:Dictionary]{Dictionary} of \link[=Task]{Tasks}: \link{mlr_tasks}
+\item \code{as.data.table(mlr_tasks)} for a table of available \link[=Task]{Tasks} in the running session (depending on the loaded packages).
+\item \CRANpkg{mlr3fselect} and \CRANpkg{mlr3filters} for feature selection and feature filtering.
+\item Extension packages for additional task types:
+\itemize{
+\item Unsupervised clustering: \CRANpkg{mlr3cluster}
+\item Probabilistic supervised regression and survival analysis: \url{https://mlr3proba.mlr-org.com/}.
+}
+}
+
+Other Task: 
+\code{\link{TaskClust}},
+\code{\link{mlr_tasks_ruspini}}
+}
+\concept{Task}


### PR DESCRIPTION
Closes: https://github.com/mlr-org/mlr3cluster/issues/47

Changes:

- Use predict generic for ClusterR package (fixed deprecation warning)
- Bump pre-commit and add missing deps
- Update lintr config
- Remove unneeded return statements (mlr3 style)
- mlr3 style task docs and templates