### PR TITLE
release: 0.1.10

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mlr3cluster
 Title: Cluster Extension for 'mlr3'
-Version: 0.1.9.9000
+Version: 0.1.10
 Authors@R: c(
     person("Damir", "Pulatov", , "damirpolat@protonmail.com", role = c("cre", "aut")),
     person("Michel", "Lang", , "michellang@gmail.com", role = "aut",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ URL: https://mlr3cluster.mlr-org.com,
     https://github.com/mlr-org/mlr3cluster
 BugReports: https://github.com/mlr-org/mlr3cluster/issues
 Depends:
-    mlr3 (>= 0.14.0),
+    mlr3 (>= 0.21.0),
     R (>= 3.1.0)
 Imports:
     backports (>= 1.1.10),
@@ -39,8 +39,6 @@ Suggests:
     RWeka,
     stream,
     testthat (>= 3.0.0)
-Remotes:
-    mlr-org/mlr3
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE, r6 = TRUE)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# mlr3cluster (development version)
+# mlr3cluster 0.1.10
 
 * Add BIRCH learner from 'stream' package
 * Add BICO learner from 'stream' package

--- a/README.Rmd
+++ b/README.Rmd
@@ -16,6 +16,7 @@ library(mlr3cluster)
 library(mlr3misc)
 lrn_clust = as.data.table(mlr3::mlr_learners)[task_type == "clust", .(key, label, packages)]
 msr_clust = as.data.table(mlr3::mlr_measures)[task_type == "clust", .(key, label, packages)]
+lrn_clust = lrn_clust[key != c("clust.bico", "clust.birch")] # remove after cran release
 ```
 
 # mlr3cluster

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ pak::pak("mlr-org/mlr3cluster")
 
 The current version of **mlr3cluster** contains:
 
-- A selection of 24 clustering learners that represent a wide variety of
-  clusterers: partitional, hierarchical, fuzzy, etc.
-- A selection of 4 performance measures
-- Two built-in tasks to get started with clustering
+-   A selection of 22 clustering learners that represent a wide variety
+    of clusterers: partitional, hierarchical, fuzzy, etc.
+-   A selection of 4 performance measures
+-   Two built-in tasks to get started with clustering
 
 Also, the package is integrated with
 **[mlr3viz](https://github.com/mlr-org/mlr3viz)** which enables you to
@@ -60,8 +60,6 @@ create great visualizations with just one line of code!
 | [clust.SimpleKMeans](https://mlr3cluster.mlr-org.com/reference/mlr_learners_clust.SimpleKMeans) | K-Means (Weka)                        | [RWeka](https://cran.r-project.org/package=RWeka)         |
 | [clust.agnes](https://mlr3cluster.mlr-org.com/reference/mlr_learners_clust.agnes)               | Agglomerative Hierarchical Clustering | [cluster](https://cran.r-project.org/package=cluster)     |
 | [clust.ap](https://mlr3cluster.mlr-org.com/reference/mlr_learners_clust.ap)                     | Affinity Propagation Clustering       | [apcluster](https://cran.r-project.org/package=apcluster) |
-| [clust.bico](https://mlr3cluster.mlr-org.com/reference/mlr_learners_clust.bico)                 | BICO Clustering                       | [stream](https://cran.r-project.org/package=stream)       |
-| [clust.birch](https://mlr3cluster.mlr-org.com/reference/mlr_learners_clust.birch)               | BIRCH Clustering                      | [stream](https://cran.r-project.org/package=stream)       |
 | [clust.cmeans](https://mlr3cluster.mlr-org.com/reference/mlr_learners_clust.cmeans)             | Fuzzy C-Means Clustering Learner      | [e1071](https://cran.r-project.org/package=e1071)         |
 | [clust.cobweb](https://mlr3cluster.mlr-org.com/reference/mlr_learners_clust.cobweb)             | Cobweb Clustering                     | [RWeka](https://cran.r-project.org/package=RWeka)         |
 | [clust.dbscan](https://mlr3cluster.mlr-org.com/reference/mlr_learners_clust.dbscan)             | Density-Based Clustering              | [dbscan](https://cran.r-project.org/package=dbscan)       |
@@ -112,10 +110,10 @@ has a section on clustering.
 
 ## Future Plans
 
-- Add more learners and measures
-- Integrate the package with
-  **[mlr3pipelines](https://github.com/mlr-org/mlr3pipelines)** (work in
-  progress)
+-   Add more learners and measures
+-   Integrate the package with
+    **[mlr3pipelines](https://github.com/mlr-org/mlr3pipelines)** (work
+    in progress)
 
 If you have any questions, feedback or ideas, feel free to open an issue
 [here](https://github.com/mlr-org/mlr3cluster/issues).

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -4,7 +4,7 @@
 
 ## revdepcheck results
 
-We checked 2 reverse dependencies, comparing R CMD check results across CRAN and dev versions of this package.
+We checked 3 reverse dependencies, comparing R CMD check results across CRAN and dev versions of this package.
 
  * We saw 0 new problems
  * We failed to check 0 packages

--- a/man-roxygen/task.R
+++ b/man-roxygen/task.R
@@ -1,5 +1,5 @@
 #' @section Dictionary:
-#' This [mlr3::Task] can be instantiated via the [dictionary][mlr3misc::Dictionary] [mlr3::mlr_tasks] or with the associated sugar function [tsk()]:
+#' This [mlr3::Task] can be instantiated via the [dictionary][mlr3misc::Dictionary] [mlr3::mlr_tasks] or with the associated sugar function [mlr3::tsk()]:
 #' ```
 #' mlr_tasks$get("<%= id %>")
 #' tsk("<%= id %>")

--- a/man/mlr_tasks_ruspini.Rd
+++ b/man/mlr_tasks_ruspini.Rd
@@ -11,7 +11,7 @@ A cluster task for the \link[cluster:ruspini]{cluster::ruspini} data set.
 }
 \section{Dictionary}{
 
-This \link[mlr3:Task]{mlr3::Task} can be instantiated via the \link[mlr3misc:Dictionary]{dictionary} \link[mlr3:mlr_tasks]{mlr3::mlr_tasks} or with the associated sugar function \code{\link[=tsk]{tsk()}}:
+This \link[mlr3:Task]{mlr3::Task} can be instantiated via the \link[mlr3misc:Dictionary]{dictionary} \link[mlr3:mlr_tasks]{mlr3::mlr_tasks} or with the associated sugar function \code{\link[mlr3:mlr_sugar]{mlr3::tsk()}}:
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{mlr_tasks$get("ruspini")
 tsk("ruspini")

--- a/man/mlr_tasks_usarrests.Rd
+++ b/man/mlr_tasks_usarrests.Rd
@@ -12,7 +12,7 @@ Rownames are stored as variable \code{"states"} with column role \code{"name"}.
 }
 \section{Dictionary}{
 
-This \link[mlr3:Task]{mlr3::Task} can be instantiated via the \link[mlr3misc:Dictionary]{dictionary} \link[mlr3:mlr_tasks]{mlr3::mlr_tasks} or with the associated sugar function \code{\link[=tsk]{tsk()}}:
+This \link[mlr3:Task]{mlr3::Task} can be instantiated via the \link[mlr3misc:Dictionary]{dictionary} \link[mlr3:mlr_tasks]{mlr3::mlr_tasks} or with the associated sugar function \code{\link[mlr3:mlr_sugar]{mlr3::tsk()}}:
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{mlr_tasks$get("usarrests")
 tsk("usarrests")


### PR DESCRIPTION
mlr3 0.21.0 will break mlr3cluster on cran. We need to release this PR directly after the mlr3 release. Change the required mlr3 version and remove remotes.