### PR TITLE
chore: bump min R version to 3.3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ URL: https://mlr3cluster.mlr-org.com,
 BugReports: https://github.com/mlr-org/mlr3cluster/issues
 Depends:
     mlr3 (>= 0.14.0),
-    R (>= 3.1.0)
+    R (>= 3.3.0)
 Imports:
     backports (>= 1.1.10),
     checkmate,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ URL: https://mlr3cluster.mlr-org.com,
 BugReports: https://github.com/mlr-org/mlr3cluster/issues
 Depends:
     mlr3 (>= 0.21.0),
-    R (>= 3.1.0)
+    R (>= 3.3.0)
 Imports:
     backports (>= 1.1.10),
     checkmate,


### PR DESCRIPTION
data.table now requires R 3.3 and the cluster package requires R 3.5. Since the data.table dep is not going to change lets bump to track the data.table version.